### PR TITLE
prevented npm error relevant with missing nucleo-icons.svg file

### DIFF
--- a/assets/scss/paper-dashboard/_nucleo-outline.scss
+++ b/assets/scss/paper-dashboard/_nucleo-outline.scss
@@ -7,7 +7,7 @@ License - nucleoapp.com/license/
 @font-face {
   font-family: 'nucleo-icons';
   src: url('../fonts/nucleo-icons.eot');
-  src: url('../fonts/nucleo-icons.eot') format('embedded-opentype'), url('../fonts/nucleo-icons.woff2') format('woff2'), url('../fonts/nucleo-icons.woff') format('woff'), url('../fonts/nucleo-icons.ttf') format('truetype'), url('../fonts/nucleo-icons.svg') format('svg');
+  src: url('../fonts/nucleo-icons.eot') format('embedded-opentype'), url('../fonts/nucleo-icons.woff2') format('woff2'), url('../fonts/nucleo-icons.woff') format('woff'), url('../fonts/nucleo-icons.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
npm is throwing error relevant with missing nucleo-icons.svg file during npm run. I fixed this issue.